### PR TITLE
Fix missing QDebug

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include <QMessageBox>
 #include <QDesktopWidget>
 #include <QtCore/QFileInfo>
+#include <QDebug>
 
 #include "DiffImgWindow.h"
 #include "AppSettings.h"


### PR DESCRIPTION
With newer version of Qt5 (5.15), compilation fails with errors such as "invalid use of incomplete type ‘class QDebug’" and "‘endl’ is not a member of ‘Qt’".
Adding QDebug include fixes the problem.